### PR TITLE
Added support for providing Hazelcast instance, added shutdown

### DIFF
--- a/src/clj_hazelcast/core.clj
+++ b/src/clj_hazelcast/core.clj
@@ -29,6 +29,15 @@
   (when-not @hazelcast
     (reset! hazelcast (make-hazelcast opts))))
 
+(defn with-instance [^HazelcastInstance instance]
+  (reset! hazelcast instance))
+
+(defn shutdown []
+  (let [instance ^HazelcastInstance @hazelcast]
+    (reset! hazelcast nil)
+    (when instance
+      (.shutdown ^HazelcastInstance instance))))
+
 ;; (init)
 
 (defn do-with-lock [lockable thunk]

--- a/test/clj_hazelcast/test/core.clj
+++ b/test/clj_hazelcast/test/core.clj
@@ -8,7 +8,8 @@
 (defn fixture [f]
   (hazelcast/init)
   (reset! test-map (hazelcast/get-map "clj-hazelcast.cluster-tests.test-map"))
-  (f))
+  (f)
+  (hazelcast/shutdown))
 
 (use-fixtures :once fixture)
 

--- a/test/clj_hazelcast/test/core_with_instance.clj
+++ b/test/clj_hazelcast/test/core_with_instance.clj
@@ -1,0 +1,27 @@
+(ns clj-hazelcast.test.core-with-instance
+  (:use [clojure.test])
+  (:require
+   [clj-hazelcast.core :as hazelcast])
+  (:import
+   com.hazelcast.core.Hazelcast))
+
+(defonce ^:const map-name "clj-hazelcast.cluster-tests-with-instance.test-map")
+
+(def hazelcast-instance (atom nil))
+
+(defn fixture [f]
+  (reset! hazelcast-instance (Hazelcast/newHazelcastInstance))
+  (hazelcast/with-instance @hazelcast-instance)
+  (f)
+  (hazelcast/shutdown))
+
+(use-fixtures :once fixture)
+
+(deftest ensure-provided-instance-used
+  "Putting via clj-hazelcast should put in the provided Hazelcast instance"
+  (let [instance-map (.getMap @hazelcast-instance map-name)
+        clj-hazelcast-map (hazelcast/get-map map-name)]
+    (is (= 456
+           (do
+             (hazelcast/put! clj-hazelcast-map :bar 456)
+             (.get instance-map :bar))))))

--- a/test/clj_hazelcast/test/mr_test.clj
+++ b/test/clj_hazelcast/test/mr_test.clj
@@ -16,7 +16,8 @@
   (reset! mr-test-map (hz/get-map "clj-hazelcast.cluster-tests.mr-test-map"))
   (reset! wordcount-map (hz/get-map "clj-hazelcast.cluster-tests.wordcount-map"))
   (reset! validation-map (hz/get-map "clj-hazelcast.cluster-tests.validation-map"))
-  (f))
+  (f)
+  (hz/shutdown))
 
 (use-fixtures :once fixture)
 


### PR DESCRIPTION
This provides a fix for #9 and also adds `shutdown`, which is very convenient for running isolated tests.
