### PR TITLE
added remove! command

### DIFF
--- a/src/clj_hazelcast/core.clj
+++ b/src/clj_hazelcast/core.clj
@@ -66,6 +66,8 @@
 (defn put-all! [^IMap dest ^Map src]
   (.putAll dest src))
 
+(defn remove! [m key] (.remove ^IMap m key))
+
 (defn clear! [m] (.clear ^IMap m))
 
 (defn add-entry-listener! [^IMap m listener-fn]

--- a/test/clj_hazelcast/test/core.clj
+++ b/test/clj_hazelcast/test/core.clj
@@ -59,3 +59,11 @@
            (:key-ttl @test-map))))
   (Thread/sleep 2000)
   (is (nil? (:key-ttl @test-map))))
+
+(deftest remove!-test
+  (is (= "to be removed"
+        (do
+          (hazelcast/put! @test-map :key-remove "to be removed")
+          (:key-remove @test-map))))
+  (hazelcast/remove! @test-map :key-remove)
+  (is (nil? (:key-remove @test-map))))


### PR DESCRIPTION
This is a vary basic addition, just to remove the need for Java interrop when using clj-hazelcast.
